### PR TITLE
Added saving test reports to ostf.log

### DIFF
--- a/cloudv_ostf_adapter/wsgi/__init__.py
+++ b/cloudv_ostf_adapter/wsgi/__init__.py
@@ -155,6 +155,12 @@ class Tests(BaseTests):
             abort(404,
                   message="Test %s not found." % test)
         reports = plugin.run_test(test)
+        with open(CONF.rest.log_file, 'a+') as f:
+            for report in reports:
+                for descr in report.description:
+                    f.write("%s: %s\n" % (descr, report.description[descr]))
+            f.write('\n' * 5)
+
         report = [r.description for r in reports]
         return {"plugin": {"name": plugin.name,
                            "test": test,


### PR DESCRIPTION
Reasons:
    - User actually don't need the whole output (traceback) of failed tests,
      but the laconic report
    - Results of tests may be important, so there's a reason of storing them
      in logs
Changes:
    - The whole report of executed OSTF tests will be logged to file defined
      by 'log_file' option in cloudv_ostf_adapter.conf

Closes-Bug: #1461932