### PR TITLE
Changed paths to logs

### DIFF
--- a/etc/cloudv_ostf_adapter/cloudv_ostf_adapter.conf
+++ b/etc/cloudv_ostf_adapter/cloudv_ostf_adapter.conf
@@ -4,9 +4,9 @@ health_check_config_path = /etc/cloudv-ostf-adapter/test.conf
 [rest]
 server_host=127.0.0.1
 server_port=8777
-log_file=/var/log/ostf.log
+log_file=/tmp/ostf/ostf.log
 debug=False
-jobs_dir=/var/log/ostf
+jobs_dir=/tmp/ostf/jobs
 
 [sanity]
 


### PR DESCRIPTION
Reasons:
    - By default, a non-root user does not have an access to /var/log
      mentioned in cloudv_ostf_adapter.conf as a default path to logs
Changes:
    - Changed paths to logs in cloudv_ostf_adapter.conf to /tmp folder

Closes-Bug: #1461912