### PR TITLE
Fixed naming issue with oslo.utils

### DIFF
--- a/cloudv_ostf_adapter/common/utils.py
+++ b/cloudv_ostf_adapter/common/utils.py
@@ -18,7 +18,7 @@ import prettytable
 import six
 
 from cloudv_ostf_adapter.common import cfg
-from oslo.utils import encodeutils
+from oslo_utils import encodeutils
 
 CONF = cfg.CONF
 


### PR DESCRIPTION
Reasons:
    - encodeutils should be imported from oslo_utils, not oslo.utils
Changes:
    - replaced oslo.utils with oslo_utils in utils.py

Closes-Bug: 1497939