### PR TITLE
Bumped version of adapter

### DIFF
--- a/cloudv_ostf_adapter/version.py
+++ b/cloudv_ostf_adapter/version.py
@@ -13,4 +13,4 @@
 #    under the License.
 
 release = "cloudv-ostf-adapter"
-version = "2015.1"
+version = "2015.9-1.0.0"


### PR DESCRIPTION
Reasons:
    - There're lots of patches which improved adapter a lot
    - Task MCV-172
    - Versioning should be controlled and better structured
Changes:
    - Bumped version of adapter to 2015.9-1.0.0
    - Version from now on has structure: YYYY.M-X.X.X

Closes-Bug: 1498004